### PR TITLE
Split by language and rough out JS implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,26 @@
+ARG NODE_IMAGE_VERSION
+ARG BASE_IMAGE=node:${NODE_IMAGE_VERSION}-alpine
+FROM ${BASE_IMAGE}
+
+# Access
+ARG GITHUB_REGISTRY_TOKEN
+RUN if [[ -n "${GITHUB_REGISTRY_TOKEN:-}" ]]; then \
+  npm config set "//npm.pkg.github.com/:_authToken" "${GITHUB_REGISTRY_TOKEN}"; fi
+RUN if [[ -n "${GITHUB_REGISTRY_TOKEN:-}" ]]; then \
+  npm whoami --registry=https://npm.pkg.github.com; fi
+
+WORKDIR /source
+
+# Install project deps
+ADD package.json package.json
+ADD yarn.lock yarn.lock
+RUN yarn install --frozen-lockfile
+
+# Install danger if it not in the project deps
+RUN yarn run danger -V &>/dev/null || yarn add --dev danger
+
+ENV DANGER_GITHUB_API_TOKEN ""
+ENV BUILDKITE ""
+ENV BUILDKITE_REPO ""
+ENV BUILDKITE_PULL_REQUEST ""
+ENV BUILDKITE_BUILD_URL ""

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ steps:
     agents:
       queue: build-unrestricted
     plugins:
-    - cultureamp/danger-systems#v0.0.1:
+    - cultureamp/danger-systems#v0.0.2:
+      language: js
+      language_version: 12
 ```
 
 Within Culture Amp’s build pipelines this will pull in the
@@ -37,7 +39,9 @@ steps:
   - label: ":zap: Danger"
     key: danger
     plugins:
-    - cultureamp/danger-systems#v0.0.1:
+    - cultureamp/danger-systems#v0.0.2:
+      language: js
+      language_version: 12
 ```
 
 2. Ensure that the API token is available to the pipeline as
@@ -64,8 +68,6 @@ message("Changed Files in this PR: \n - " + modifiedMD)
 
 ## Limitations
 
-* The plugin does not install any additional dependencies as yet, so your
-  `dangerfile` will only have access to the methods exposed by `danger.
 * The plugin is only configured to work with GitHub
 
 ## Developing

--- a/bin/danger_js
+++ b/bin/danger_js
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+BUILDKITE_DANGER_SYSTEMS_LANGUAGE_VERSION=${BUILDKITE_DANGER_SYSTEMS_LANGUAGE_VERSION:-"12"}
+GITHUB_REGISTRY_TOKEN=${GITHUB_REGISTRY_TOKEN:-}
+
+echo "--- :docker: Building danger-js image"
+docker build \
+  -t cultureamp/danger-js \
+  --build-arg NODE_IMAGE_VERSION="${BUILDKITE_DANGER_SYSTEMS_LANGUAGE_VERSION}" \
+  --build-arg GITHUB_REGISTRY_TOKEN="${GITHUB_REGISTRY_TOKEN}" \
+  -f ./Dockerfile.node "$(pwd)"
+
+# Note this ENV var differs from the `DANGER_GITHUB_API_TOKEN` that danger
+# expects to be available for reasons of descriptiveness
+DANGER_SYSTEMS_GITHUB_TOKEN=${DANGER_SYSTEMS_GITHUB_TOKEN:-}
+BUILDKITE=${BUILDKITE:-}
+BUILDKITE_REPO=${BUILDKITE_REPO:-}
+BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST:-}
+BUILDKITE_BUILD_URL=${BUILDKITE_BUILD_URL:-}
+
+echo "--- :docker: Running danger-js"
+docker run \
+  --rm \
+  -v "$(pwd)":/source \
+  -e DANGER_GITHUB_API_TOKEN="$DANGER_SYSTEMS_GITHUB_TOKEN" \
+  -e BUILDKITE="$BUILDKITE" \
+  -e BUILDKITE_REPO="$BUILDKITE_REPO" \
+  -e BUILDKITE_PULL_REQUEST="$BUILDKITE_PULL_REQUEST" \
+  -e BUILDKITE_BUILD_URL="$BUILDKITE_BUILD_URL" \
+  cultureamp/danger-js \
+  yarn run danger ci

--- a/bin/danger_ruby
+++ b/bin/danger_ruby
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- :docker: Running danger-ruby if it were implemented"

--- a/hooks/command
+++ b/hooks/command
@@ -1,23 +1,22 @@
 #!/bin/bash
 set -euo pipefail
 
-# Note this ENV var differs from the `DANGER_GITHUB_API_TOKEN` that danger
-# expects to be available for reasons of descriptiveness
-DANGER_SYSTEMS_GITHUB_TOKEN=${DANGER_SYSTEMS_GITHUB_TOKEN:-}
-BUILDKITE=${BUILDKITE:-}
-BUILDKITE_REPO=${BUILDKITE_REPO:-}
+BUILDKITE_DANGER_SYSTEMS_LANGUAGE=${BUILDKITE_DANGER_SYSTEMS_LANGUAGE:-}
 BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST:-}
-BUILDKITE_BUILD_URL=${BUILDKITE_BUILD_URL:-}
 
-echo "--- :docker: Running danger-js"
-docker run \
-  --rm \
-  -v "$(pwd)":/source \
-  -w /source \
-  -e DANGER_GITHUB_API_TOKEN="$DANGER_SYSTEMS_GITHUB_TOKEN" \
-  -e BUILDKITE="$BUILDKITE" \
-  -e BUILDKITE_REPO="$BUILDKITE_REPO" \
-  -e BUILDKITE_PULL_REQUEST="$BUILDKITE_PULL_REQUEST" \
-  -e BUILDKITE_BUILD_URL="$BUILDKITE_BUILD_URL" \
-  node:12-alpine \
-  npx danger ci
+# Return early if there’s no PR to comment against
+if [[ -z "${BUILDKITE_PULL_REQUEST:-}" ]]; then
+  echo "Skipping, no pull request"
+  exit 0
+fi;
+
+if [[ -z "$BUILDKITE_DANGER_SYSTEMS_LANGUAGE" ]]; then
+  # Ensure a language is specified
+  echo "You must specify a language for danger to use"
+  buildkite-agent annotate --style error
+  exit 1
+elif [ "$BUILDKITE_DANGER_SYSTEMS_LANGUAGE" == "js" ]; then
+  bin/danger_js
+elif [ "$BUILDKITE_DANGER_SYSTEMS_LANGUAGE" == "ruby" ]; then
+  bin/danger_ruby
+fi;

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: Danger Systems
 description: Run danger as part of your pipeline
 author: https://github.com/cultureamp
-requirements: []
+requirements: ["docker"]
 configuration:
   properties: {}
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -3,5 +3,13 @@ description: Run danger as part of your pipeline
 author: https://github.com/cultureamp
 requirements: ["docker"]
 configuration:
-  properties: {}
+  properties:
+    language:
+      type: string
+      enum:
+        - js
+        - ruby
+    language_version:
+      type: string
+  required: ["language", "language_version"]
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+@test "Exits early when no associated PR" {
+  export BUILDKITE_PULL_REQUEST=""
+
+  run "$PWD/hooks/command"
+
+  assert_success
+}
+
+@test "Fails when no language specified" {
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_DANGER_SYSTEMS_LANGUAGE=""
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+}
+
+@test "Runs danger-js when js specified as language" {
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_DANGER_SYSTEMS_LANGUAGE="js"
+
+  stub docker "docker output"
+
+  run "$PWD/hooks/command"
+
+  assert_output --partial "Running danger-js"
+
+  assert_success
+}
+
+@test "Runs danger-ruby when ruby specified as language" {
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_DANGER_SYSTEMS_LANGUAGE="ruby"
+
+  stub docker "docker output"
+
+  run "$PWD/hooks/command"
+
+  assert_output --partial "Running danger-ruby"
+
+  assert_success
+}


### PR DESCRIPTION
Add the basic structure for allowing users to specify a `language` and a `language_version` to handle the environment for running danger in.

Only implements an attempt at a JS/node version so far.